### PR TITLE
Quote class name in publish command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ configuration is used:
 
 This package publishes its configuration to `vault.php`. This can be done with:
 ```
-php artisan vendor:publish --provider=InsitesConsulting\AzureKeyVault\ServiceProvider
+php artisan vendor:publish --provider='InsitesConsulting\AzureKeyVault\ServiceProvider'
 ```
 
 The configuration entries are as follows:


### PR DESCRIPTION
The fully-qualified class name contains backslashes, and this causes
publishing to silently fail since many shells will strip these. Enclose
the name in quotes to avoid this.

closes #4 